### PR TITLE
Fixed 'update-symlinks' to support nested links

### DIFF
--- a/update-symlinks
+++ b/update-symlinks
@@ -53,7 +53,8 @@ if __name__ == '__main__':
             symlink_from = symlink_from[:-1]
 
         symlink_from_full = os.path.expanduser(symlink_from)
-        symlink_to_full = os.path.relpath(os.path.join(config_dir, symlink_to), HOME_DIR)
+        symlink_to_start = os.path.realpath(os.path.dirname(symlink_from_full))
+        symlink_to_full = os.path.relpath(os.path.join(config_dir, symlink_to), symlink_to_start)
 
         should_link = True
         if os.path.lexists(symlink_from_full):


### PR DESCRIPTION
This fix adds support for links like this
 '~/.rvm/hooks/my_hook -> rvm/my_hook'

Without this fix the created link will be incorect (relative to HOME_DIR):
 ~/.rvm/hooks/my_hook -> rel_to_home_path_to_dotfile_project/rvm/my_hook
